### PR TITLE
Added check for navigateViaTrackpad before GestureRecognizers

### DIFF
--- a/WebShell/WSTrackpadGestures.swift
+++ b/WebShell/WSTrackpadGestures.swift
@@ -23,6 +23,10 @@ extension ViewController: NSGestureRecognizerDelegate {
      @wdg #44: Support Trackpad gestures
 	 */
 	func WSinitSwipeGestures() {
+		if !(WebShellSettings["navigateViaTrackpad"] as! Bool) {
+         	   return; // we don't need to intialize gestures if we don't need them (fixes selection on web with 3 fingers pan)
+	        }
+		
 		mainWebview.acceptsTouchEvents = true
 		self.view.acceptsTouchEvents = true
 


### PR DESCRIPTION
I found that I can't do 3finger pan selection and I had navigateViaTrackpad set to false and got many console events about panning.

I found this solution might work, but I'm open for suggestions and improvements