### PR TITLE
Force unwrap key string when fetching from localStorage

### DIFF
--- a/WebShell/WSInjector.swift
+++ b/WebShell/WSInjector.swift
@@ -149,15 +149,20 @@ import WebKit
 		
 		let getFromLocal: @convention(block)(NSString!) -> String = {(key: NSString!) in
 			let host: String = (self.mainWebview.mainFrame.dataSource?.request.url?.host)!
-			let newKey = "WSLS:\(host):\(key!)"
-			let val = UserDefaults.standard.value(forKey: newKey as String)
-			
-			if let myVal = val as? String {
-				return String(myVal)
-			}
-			else {
-				return "null"
-			}
+            if let LSvalue = key {
+                let newKey = "WSLS:\(host):\(LSvalue)"
+                
+                let val = UserDefaults.standard.value(forKey: newKey as String)
+                
+                if let myVal = val as? String {
+                    return String(myVal)
+                }
+                else {
+                    return "null"
+                }
+            } else {
+                return "null"
+            }
 		}
 		
 		jsContext.objectForKeyedSubscript("localStorage").setObject(unsafeBitCast(saveToLocal, to: AnyObject.self), forKeyedSubscript: "setItem" as (NSCopying & NSObjectProtocol)!)

--- a/WebShell/WSInjector.swift
+++ b/WebShell/WSInjector.swift
@@ -149,7 +149,7 @@ import WebKit
 		
 		let getFromLocal: @convention(block)(NSString!) -> String = {(key: NSString!) in
 			let host: String = (self.mainWebview.mainFrame.dataSource?.request.url?.host)!
-			let newKey = "WSLS:\(host):\(key)"
+			let newKey = "WSLS:\(host):\(key!)"
 			let val = UserDefaults.standard.value(forKey: newKey as String)
 			
 			if let myVal = val as? String {


### PR DESCRIPTION
It took me an embarrassingly long time to find this bug. 

I have been trying to setup [The Lounge](https://github.com/thelounge/thelounge) as a WebShell app, but sessions were not saved at all. Well it turns out that while WebShell saves the data correctly, fetching our localStorage data with a key containing "Optional(key)" does not work, so force-unwrapping the key seems like the most feasible thing to do, which is exactly what this pull request does.

(There are still some weird problems with The Lounge, like not reading from localStorage at all sometimes, but at least session data is read correctly now. I might propose a few more pull requests if those problems are rooted in WebShell, not sure about it at the moment.)