### PR TITLE
Hook localStorage functions as soon as possible to prevent race conditions

### DIFF
--- a/WebShell/Core/WSWebViewFunctions.swift
+++ b/WebShell/Core/WSWebViewFunctions.swift
@@ -101,5 +101,7 @@ extension WSViewController {
         if settings.useDocumentTitle {
             mainWindow.window?.title = title
         }
+        
+        self.injectLocalStorage(jsContext: frame.javaScriptContext)
     }
 }


### PR DESCRIPTION
It's about [The Lounge](https://github.com/thelounge/thelounge) again. I already mentioned in my last pull request that WebShell's localStorage hooks don't get called on around 50% of the runs, which leaves the user at the login screen.

The reason behind this is a simple race condition. The Lounge tries to read localStorage directly on load of the page, and sometimes that happens before our localStorage hooks are in place and installed. 

I solved this by installing the hooks at the apparently earliest possible moment that is already available in the code base, the _didReceiveTitle_ callback. With this I haven't had the race condition happen again in like 20 test runs, so I assume it should be fixed now.